### PR TITLE
Remove beta URL segment for Castamatic

### DIFF
--- a/server/data/apps.json
+++ b/server/data/apps.json
@@ -565,7 +565,7 @@
         "appType": [
             "app"
         ],
-        "appUrl": "https://castamatic.com/beta",
+        "appUrl": "https://castamatic.com/",
         "appIconUrl": "castamatic.png",
         "platforms": [
             "iOS"


### PR DESCRIPTION
I am new to the Postcast Index and Castamatic.

I wanted to try out the Value4Value idea and Castamatic happened to be the first app I tried. The link on the [apps](https://podcastindex.org/apps) page pointed to the Castamatic TestFlight beta which confused me at first. I downloaded the main Castamatic app, not the beta, and it seems to support all the features from the `supportedElements` so I suppose the beta link is no longer needed?